### PR TITLE
Add an option for non-production robots.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e DUID=1000` | for UserID - see below for explanation |
 | `-e DGID=1000` | for GroupID - see below for explanation |
 | `-e GRAV_MULTISITE=subdirectory` | Deploy a Grav multisite (subdirectory) installation |
+| `-e ROBOTS_DISALLOW=false` | Replace default /robots.txt file with one discouraging indexers |
 | `-v /var/www/backup` | Contains your location for Grav backups |
 | `-v /var/www/logs` | Contains your location for your Grav log files |
 | `-v /var/www/user` | Contains your Grav content |

--- a/root/init-admin
+++ b/root/init-admin
@@ -41,10 +41,17 @@ if [[ -n "${GRAV_MULTISITE}" && "$GRAV_MULTISITE" == "subdirectory" ]]; then
   mkdir -p /var/www/grav/user/sites
 fi
 
+# Copy robots.txt file with disallow everything directive if set
+ROBOTS_DISALLOW=${ROBOTS_DISALLOW:-false}
+if [[ $ROBOTS_DISALLOW == "true" ]]; then
+  echo "Copying disallowing robots.txt .."
+  cp -f /tmp/extras/robots.disallow.txt /var/www/grav/robots.txt
+fi
+
 # Clean
 rm -rf /grav
 rm -rf /var/www/html
-rm -rf /tmp/env
+rm -rf /tmp/env /tmp/extras
 
 DUID=${DUID:-911}
 DGID=${DGID:-911}

--- a/root/init-core
+++ b/root/init-core
@@ -41,10 +41,17 @@ if [[ -n "${GRAV_MULTISITE}" && "$GRAV_MULTISITE" == "subdirectory" ]]; then
   mkdir -p /var/www/grav/user/sites
 fi
 
+# Copy robots.txt file with disallow everything directive if set
+ROBOTS_DISALLOW=${ROBOTS_DISALLOW:-false}
+if [[ $ROBOTS_DISALLOW == "true" ]]; then
+  echo "Copying disallowing robots.txt .."
+  cp -f /tmp/extras/robots.disallow.txt /var/www/grav/robots.txt
+fi
+
 # Clean
 rm -rf /grav
 rm -rf /var/www/html
-rm -rf /tmp/env
+rm -rf /tmp/env /tmp/extras
 
 DUID=${DUID:-911}
 DGID=${DGID:-911}

--- a/root/tmp/extras/robots.disallow.txt
+++ b/root/tmp/extras/robots.disallow.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This is pretty much straight out of [my own Caddy-based grav image](https://github.com/hughbris/grav-daddy/blob/5a954c0afdfc14c1d005b5dd6cb787f21aecdf4e/init/init-grav#L51). I still use your nginx image for at least one multisite because the multisite setup does not seem to work under Caddy.

I find it an invaluable option for staging environments so that they won't be indexed. (I have now given up trying to protect staging environments with HTTP auth and explaining that to clients!).

Of course, the `/robots.txt` file sits above Grav's `user` folder and is out of reach of the standard bind mounts.

Other ways this could be achieved:
* bind mount the robots.txt file
* General recipe: [Display different robots.txt contents for different environments](https://learn.getgrav.org/17/cookbook/general-recipes#display-different-robots-)

So, while not essential, this seems simplest, and I make use of it plenty.