### PR TITLE
docs: fix README parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ Container images are configured using parameters passed at runtime (such as thos
 
 |               Parameter               | Function                                                         |
 | :-----------------------------------: | ---------------------------------------------------------------- |
-|                `-p 80`                | Http webUI.                                                      |
+|                `-p 80`                | Http webUI                                                       |
 |            `-e DUID=1000`             | for UserID - see below for explanation                           |
 |            `-e DGID=1000`             | for GroupID - see below for explanation                          |
-| `-e TZ-e GRAV_MULTISITE=subdirectory` | Deploy a Grav multisite (subdirectory) installation.             |
-|      `-e ROBOTS_DISALLOW=false`       | Replace default /robots.txt file with one discouraging indexers. |
+|      `-e TZ=America/Los_Angeles`      | Set your timezone                                                |
+|      `-e GRAV_MULTISITE=subdirectory` | Deploy a Grav multisite (subdirectory) installation              |
+|      `-e ROBOTS_DISALLOW=false`       | Replace default /robots.txt file with one discouraging indexers  |
 |         `-v /var/www/backup`          | Contains your location for Grav backups                          |
 |          `-v /var/www/logs`           | Contains your location for your Grav log files                   |
 |          `-v /var/www/user`           | Contains your Grav content                                       |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting a pull request please check the following -->

<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile.gravcore should be replicated in Dockerfile.gravcoreadmin if applicable -->
<!--- 3. Indentation style (2 spaces) should match the rest of the document -->

---

- [X] I have read the [contributing](https://github.com/dsavell/docker-grav/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

---

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

Fix a typo in the README, remove punctuation to make it uniform across all lines

## Benefits of this PR and context:

The current text in the README has a syntax error and users will see an error if they use it.

## How Has This Been Tested?

No testing since this is purely documentation.

## Source / References:

N/A
