### PR TITLE
Install plugins automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ Container images are configured using parameters passed at runtime (such as thos
 
 |               Parameter               | Function                                                         |
 | :-----------------------------------: | ---------------------------------------------------------------- |
-|                `-p 80`                | Http webUI.                                                      |
+|                `-p 80`                | Http webUI                                                       |
 |            `-e DUID=1000`             | for UserID - see below for explanation                           |
 |            `-e DGID=1000`             | for GroupID - see below for explanation                          |
-| `-e TZ-e GRAV_MULTISITE=subdirectory` | Deploy a Grav multisite (subdirectory) installation.             |
-|      `-e ROBOTS_DISALLOW=false`       | Replace default /robots.txt file with one discouraging indexers. |
+|      `-e TZ=America/Los_Angeles`      | Set your timezone                                                |
+|      `-e GRAV_MULTISITE=subdirectory` | Deploy a Grav multisite (subdirectory) installation              |
+|      `-e ROBOTS_DISALLOW=false`       | Replace default /robots.txt file with one discouraging indexers  |
 |         `-v /var/www/backup`          | Contains your location for Grav backups                          |
 |          `-v /var/www/logs`           | Contains your location for your Grav log files                   |
 |          `-v /var/www/user`           | Contains your Grav content                                       |

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Container images are configured using parameters passed at runtime (such as thos
 |            `-e DGID=1000`             | for GroupID - see below for explanation                          |
 |      `-e TZ=America/Los_Angeles`      | Set your timezone                                                |
 |      `-e GRAV_MULTISITE=subdirectory` | Deploy a Grav multisite (subdirectory) installation              |
+|   `-e GRAV_PLUGINS=devtools,precache` | Install extra plugins automaticall (must be comma separated)     |
 |      `-e ROBOTS_DISALLOW=false`       | Replace default /robots.txt file with one discouraging indexers  |
 |         `-v /var/www/backup`          | Contains your location for Grav backups                          |
 |          `-v /var/www/logs`           | Contains your location for your Grav log files                   |

--- a/root/init-admin
+++ b/root/init-admin
@@ -47,8 +47,17 @@ case $GRAV_MULTISITE in
     mkdir -p /var/www/grav/user/sites
     ;;
   *)
+  echo "Multisite not enabled, continuing"
   ;;
 esac
+
+# install plugins
+if [[ "${GRAV_PLUGINS}x" != "x" ]]; then
+  IFS=',' read -ra plugins <<< "$GRAV_PLUGINS"
+  for plugin in "${plugins[@]}"; do
+    bin/gpm install -n "${plugin}"
+  done
+fi
 
 # allow specifying a custom client_max_body_size for nginx
 if [[ -n $NGINX_CLIENT_MAX_BODY_SIZE ]]; then

--- a/root/init-core
+++ b/root/init-core
@@ -51,6 +51,14 @@ case $GRAV_MULTISITE in
     ;;
 esac
 
+# install plugins
+if [[ "${GRAV_PLUGINS}x" != "x" ]]; then
+  IFS=',' read -ra plugins <<< "$GRAV_PLUGINS"
+  for plugin in "${plugins[@]}"; do
+    bin/gpm install -n "${plugin}"
+  done
+fi
+
 # allow specifying a custom client_max_body_size for nginx
 if [[ -n $NGINX_CLIENT_MAX_BODY_SIZE ]]; then
   sed -i.bak "s/client_max_body_size .*;/client_max_body_size ${NGINX_CLIENT_MAX_BODY_SIZE};/g" /etc/nginx/nginx.conf


### PR DESCRIPTION
- [X] I have read the [contributing](https://github.com/dsavell/docker-grav/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

---

## Description:

Introduce `GRAV_PLUGINS`, which can be set to a comma-separated list of plugins to install automatically.

## Benefits of this PR and context:

Configuring sites is one of the most tedious aspects of creating sites, this PR would allow you to specify plugins to install automatically as an environment variable so you don't have to run CLI commands or use the Admin UI.

## How Has This Been Tested?

Ran on a live site with `GRAV_PLUGINS` set to a plugin that was already installed and one that was not installed. The script handled the already installed plugin correctly and also installed the new plugin with no issue.

I built an `admin` variant of this with base version `1.7.42.3` as an image on Docker Hub for testing:

`tyzbit/grav:install-plugins-automatically`

## Source / References:

N/A

## DIscussion

Would this be useful to install the admin plugin and allow us to publish just one version instead of an additional `admin` version?